### PR TITLE
errors on empty performance LIST

### DIFF
--- a/modules/xray/xray.class.php
+++ b/modules/xray/xray.class.php
@@ -666,6 +666,7 @@ class xray extends module
 					$responce = [];
 					$responce['MODE'] = 'performance';
 					$responce['TOTAL'] = $total;
+					$responce['LIST'] = [];
 					
 					for ($i = 0; $i < $total; $i++) {
 						$responce['LIST'][$i]['OPERATION'] = htmlspecialchars($res[$i]['OPERATION']);


### PR DESCRIPTION
On empty $responce['LIST'], the array_reverse generates error "array_reverse() expects parameter 1 to be array, null given",
what in turn ends up as JS-error: "Uncaught SyntaxError: Unexpected token '<', "<br />"