### PR TITLE
failsafe when no app_player module is installed

### DIFF
--- a/modules/application.class.php
+++ b/modules/application.class.php
@@ -199,6 +199,9 @@ function getParams() {
     $this->redirect(ROOTHTML.'admin.php');
    }
 
+   if (file_exists(DIR_MODULES.'app_player')) {
+    $out['SHOW_PLAYER']=1;
+   }
 
    $terminals = getAllTerminals(-1, 'TITLE');
    $total=count($terminals);

--- a/templates/default.html
+++ b/templates/default.html
@@ -32,9 +32,11 @@
                             </td>
                         </table>
                     </td>
+                    [#if SHOW_PLAYER=="1"#]
                     <td align="right">
                         [#module name="app_player" mode="header"#]
                     </td>
+                    [#endif#]
                     <td align="center">
                         <a href="<#ROOTHTML#>admin.php" class="btn btn-default btn-sm"><#LANG_CONTROL_PANEL#></a>
                     </td>


### PR DESCRIPTION
once _app_player_ module is uninstalled, an error is displayed at home page header